### PR TITLE
Sim card selection to proceed with ussd code request

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.github.muellerma.prepaidbalance">
 
     <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/ui/MainActivity.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/ui/MainActivity.kt
@@ -25,6 +25,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.github.muellerma.prepaidbalance.R
 import com.github.muellerma.prepaidbalance.databinding.ActivityMainBinding
 import com.github.muellerma.prepaidbalance.room.AppDatabase
+import com.github.muellerma.prepaidbalance.utils.hasPermission
 import com.github.muellerma.prepaidbalance.utils.prefs
 import com.github.muellerma.prepaidbalance.work.CheckBalanceWorker
 import com.github.muellerma.prepaidbalance.work.CheckBalanceWorker.Companion.CheckResult
@@ -187,7 +188,7 @@ class MainActivity : AppCompatActivity(), CoroutineScope, SwipeRefreshLayout.OnR
 
     private fun setDefaultSubscriptionId() {
         val subscriptionManager = getSystemService(SubscriptionManager::class.java)
-        if (ActivityCompat.checkSelfPermission(this, READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
+        if (hasPermission(READ_PHONE_STATE)) {
             val defaultSubscriptionId = subscriptionManager.activeSubscriptionInfoList.firstOrNull()?.subscriptionId
             prefs().edit {
                 putString("subscription_id", "$defaultSubscriptionId")

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/ui/MainActivity.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/ui/MainActivity.kt
@@ -3,7 +3,6 @@ package com.github.muellerma.prepaidbalance.ui
 import android.Manifest.permission.CALL_PHONE
 import android.Manifest.permission.READ_PHONE_STATE
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -15,7 +14,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
@@ -25,7 +23,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.github.muellerma.prepaidbalance.R
 import com.github.muellerma.prepaidbalance.databinding.ActivityMainBinding
 import com.github.muellerma.prepaidbalance.room.AppDatabase
-import com.github.muellerma.prepaidbalance.utils.hasPermission
+import com.github.muellerma.prepaidbalance.utils.hasPermissions
 import com.github.muellerma.prepaidbalance.utils.prefs
 import com.github.muellerma.prepaidbalance.work.CheckBalanceWorker
 import com.github.muellerma.prepaidbalance.work.CheckBalanceWorker.Companion.CheckResult
@@ -188,7 +186,7 @@ class MainActivity : AppCompatActivity(), CoroutineScope, SwipeRefreshLayout.OnR
 
     private fun setDefaultSubscriptionId() {
         val subscriptionManager = getSystemService(SubscriptionManager::class.java)
-        if (hasPermission(READ_PHONE_STATE)) {
+        if (hasPermissions(READ_PHONE_STATE)) {
             val defaultSubscriptionId = subscriptionManager.activeSubscriptionInfoList.firstOrNull()?.subscriptionId
             prefs().edit {
                 putString("subscription_id", "$defaultSubscriptionId")

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
@@ -1,13 +1,18 @@
 package com.github.muellerma.prepaidbalance.ui
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
+import android.telephony.SubscriptionManager
 import android.text.InputType
 import android.view.MenuItem
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.fragment.app.commit
 import androidx.preference.EditTextPreference
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.work.WorkManager
@@ -66,6 +71,22 @@ class PreferenceActivity : AppCompatActivity() {
                 } else {
                     getString(R.string.ussd_code_summary, currentValue)
                 }
+            }
+
+            if (ActivityCompat.checkSelfPermission(requireContext(),
+                    Manifest.permission.READ_PHONE_STATE
+                ) == PackageManager.PERMISSION_GRANTED) {
+
+                val subscriptionManager = requireContext().getSystemService(SubscriptionManager::class.java)
+                val (subscriptionIds, carrierNames) = subscriptionManager.activeSubscriptionInfoList.let { subscriptions ->
+                    val subscriptionIds = subscriptions.map { "${it.subscriptionId}" }.toTypedArray()
+                    val carrierNames = subscriptions.map { it.carrierName }.toTypedArray()
+                    subscriptionIds to carrierNames
+                }
+
+                val subscriptionIdPref: ListPreference = getPreference("subscription_id") as ListPreference
+                subscriptionIdPref.entries = carrierNames
+                subscriptionIdPref.entryValues = subscriptionIds
             }
 
             val workPref = getPreference("periodic_checks")

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
@@ -84,7 +84,7 @@ class PreferenceActivity : AppCompatActivity() {
                     subscriptionIds to carrierNames
                 }
 
-                val subscriptionIdPref: ListPreference = getPreference("subscription_id") as ListPreference
+                val subscriptionIdPref = getPreference("subscription_id") as ListPreference
                 subscriptionIdPref.entries = carrierNames
                 subscriptionIdPref.entryValues = subscriptionIds
             }

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
@@ -20,6 +20,7 @@ import androidx.work.WorkManager
 import com.github.muellerma.prepaidbalance.R
 import com.github.muellerma.prepaidbalance.databinding.ActivityPreferenceBinding
 import com.github.muellerma.prepaidbalance.room.AppDatabase
+import com.github.muellerma.prepaidbalance.utils.hasPermission
 import com.github.muellerma.prepaidbalance.utils.isValidUssdCode
 import com.github.muellerma.prepaidbalance.utils.prefs
 import com.github.muellerma.prepaidbalance.work.CheckBalanceWorker
@@ -56,7 +57,6 @@ class PreferenceActivity : AppCompatActivity() {
 
 
     class MainSettingsFragment : PreferenceFragmentCompat() {
-
         private val requestPermissionLauncher = registerForActivityResult(
             ActivityResultContracts.RequestPermission()
         ) { isGranted ->
@@ -83,11 +83,7 @@ class PreferenceActivity : AppCompatActivity() {
                 }
             }
 
-            if (ActivityCompat.checkSelfPermission(
-                    requireContext(),
-                    Manifest.permission.READ_PHONE_STATE
-                ) == PackageManager.PERMISSION_GRANTED
-            ) {
+            if (requireContext().hasPermission(Manifest.permission.READ_PHONE_STATE)) {
                 addSubscriptionList()
             } else {
                 getPreference("subscription_id").isEnabled = false
@@ -161,11 +157,9 @@ class PreferenceActivity : AppCompatActivity() {
         }
 
         private fun addSubscriptionList() {
-            if (ActivityCompat.checkSelfPermission(
-                    requireContext(),
-                    Manifest.permission.READ_PHONE_STATE
-                ) != PackageManager.PERMISSION_GRANTED
-            ) return
+            if (!requireContext().hasPermission(Manifest.permission.READ_PHONE_STATE)) {
+                return
+            }
             val subscriptionManager = requireContext().getSystemService(SubscriptionManager::class.java)
             val (subscriptionIds, carrierNames) = subscriptionManager.activeSubscriptionInfoList.let { subscriptions ->
                 val subscriptionIds = subscriptions.map { "${it.subscriptionId}" }.toTypedArray()

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
@@ -1,7 +1,6 @@
 package com.github.muellerma.prepaidbalance.ui
 
 import android.Manifest
-import android.content.pm.PackageManager
 import android.os.Bundle
 import android.telephony.SubscriptionManager
 import android.text.InputType
@@ -9,7 +8,6 @@ import android.view.MenuItem
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.fragment.app.commit
 import androidx.preference.EditTextPreference
@@ -20,7 +18,7 @@ import androidx.work.WorkManager
 import com.github.muellerma.prepaidbalance.R
 import com.github.muellerma.prepaidbalance.databinding.ActivityPreferenceBinding
 import com.github.muellerma.prepaidbalance.room.AppDatabase
-import com.github.muellerma.prepaidbalance.utils.hasPermission
+import com.github.muellerma.prepaidbalance.utils.hasPermissions
 import com.github.muellerma.prepaidbalance.utils.isValidUssdCode
 import com.github.muellerma.prepaidbalance.utils.prefs
 import com.github.muellerma.prepaidbalance.work.CheckBalanceWorker
@@ -83,7 +81,7 @@ class PreferenceActivity : AppCompatActivity() {
                 }
             }
 
-            if (requireContext().hasPermission(Manifest.permission.READ_PHONE_STATE)) {
+            if (requireContext().hasPermissions(Manifest.permission.READ_PHONE_STATE)) {
                 addSubscriptionList()
             } else {
                 getPreference("subscription_id").isEnabled = false
@@ -157,7 +155,7 @@ class PreferenceActivity : AppCompatActivity() {
         }
 
         private fun addSubscriptionList() {
-            if (!requireContext().hasPermission(Manifest.permission.READ_PHONE_STATE)) {
+            if (!requireContext().hasPermissions(Manifest.permission.READ_PHONE_STATE)) {
                 return
             }
             val subscriptionManager = requireContext().getSystemService(SubscriptionManager::class.java)

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/utils/ExtensionFunctions.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/utils/ExtensionFunctions.kt
@@ -51,5 +51,8 @@ fun Context.showToast(@StringRes msg: Int) {
         .show()
 }
 
-fun Context.hasPermission(permission: String) =
-    ActivityCompat.checkSelfPermission(this, permission ) == PackageManager.PERMISSION_GRANTED
+fun Context.hasPermissions(vararg permissions: String): Boolean {
+    return permissions
+        .map { permission -> ActivityCompat.checkSelfPermission(this, permission) }
+        .all { result -> result == PackageManager.PERMISSION_GRANTED }
+}

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/utils/ExtensionFunctions.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/utils/ExtensionFunctions.kt
@@ -4,11 +4,13 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.text.format.DateFormat
 import android.util.Log
 import android.widget.Toast
 import androidx.annotation.StringRes
+import androidx.core.app.ActivityCompat
 import androidx.preference.PreferenceManager
 import com.github.muellerma.prepaidbalance.R
 
@@ -48,3 +50,6 @@ fun Context.showToast(@StringRes msg: Int) {
         .makeText(this, msg, Toast.LENGTH_SHORT)
         .show()
 }
+
+fun Context.hasPermission(permission: String) =
+    ActivityCompat.checkSelfPermission(this, permission ) == PackageManager.PERMISSION_GRANTED

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/work/CheckBalanceWorker.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/work/CheckBalanceWorker.kt
@@ -104,11 +104,7 @@ class CheckBalanceWorker(
                     .deleteBefore(System.currentTimeMillis() - 6L * 30 * 24 * 60 * 60 * 1000)
             }
 
-            if (ActivityCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.CALL_PHONE
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
+            if (!context.hasPermission(Manifest.permission.CALL_PHONE)) {
                 return callback(CheckResult.MISSING_PERMISSIONS, null)
             }
 

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/work/CheckBalanceWorker.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/work/CheckBalanceWorker.kt
@@ -94,7 +94,7 @@ class CheckBalanceWorker(
             }
         }
 
-        fun checkBalance(context: Context, callback: (CheckResult, String?) -> Unit) {
+        fun checkBalance(context: Context, subscriptionId: Int? = null, callback: (CheckResult, String?) -> Unit) {
             CoroutineScope(Dispatchers.IO).launch {
                 Log.d(TAG, "Remove entries older than 6 months")
                 AppDatabase
@@ -156,12 +156,13 @@ class CheckBalanceWorker(
             }
 
             Log.d(TAG, "Send USSD request to $ussdCode")
-            context.getSystemService(TelephonyManager::class.java)
-                .sendUssdRequest(
-                    ussdCode,
-                    ussdResponseCallback,
-                    Handler(Looper.getMainLooper())
-                )
+            var telephonyManager = context.getSystemService(TelephonyManager::class.java)
+            subscriptionId?.let { telephonyManager = telephonyManager.createForSubscriptionId(it) }
+            telephonyManager.sendUssdRequest(
+                ussdCode,
+                ussdResponseCallback,
+                Handler(Looper.getMainLooper())
+            )
         }
 
         private fun handleNewBalance(

--- a/app/src/main/java/com/github/muellerma/prepaidbalance/work/CheckBalanceWorker.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/work/CheckBalanceWorker.kt
@@ -5,14 +5,12 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
-import android.content.pm.PackageManager
 import android.os.Handler
 import android.os.Looper
 import android.telephony.TelephonyManager
 import android.telephony.TelephonyManager.USSD_ERROR_SERVICE_UNAVAIL
 import android.telephony.TelephonyManager.USSD_RETURN_FAILURE
 import android.util.Log
-import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.work.*
 import com.github.muellerma.prepaidbalance.R
@@ -104,7 +102,7 @@ class CheckBalanceWorker(
                     .deleteBefore(System.currentTimeMillis() - 6L * 30 * 24 * 60 * 60 * 1000)
             }
 
-            if (!context.hasPermission(Manifest.permission.CALL_PHONE)) {
+            if (!context.hasPermissions(Manifest.permission.CALL_PHONE, Manifest.permission.READ_PHONE_STATE)) {
                 return callback(CheckResult.MISSING_PERMISSIONS, null)
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,6 @@
     <string name="invalid_subscription">Invalid sim card selected, check settings</string>
     <string name="ussd_code">USSD code</string>
     <string name="subscription_id">Sim card</string>
-    <string name="subscription_summary">Change default sim card</string>
     <string name="ussd_code_summary">The app queries the USSD code %s to get the current balance</string>
     <string name="ussd_code_default" translatable="false"/>
     <string name="general">General</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,9 +18,9 @@
     <string name="channel_name_balance_increased">Balance increased</string>
     <string name="channel_name_threshold_reached">Threshold reached</string>
     <string name="invalid_ussd_code">Invalid USSD code entered</string>
-    <string name="invalid_subscription">Invalid Subscription, check default</string>
+    <string name="invalid_subscription">Invalid sim card selected, check settings</string>
     <string name="ussd_code">USSD code</string>
-    <string name="subscription_id">Subscription</string>
+    <string name="subscription_id">Sim card</string>
     <string name="subscription_summary">Change default sim card</string>
     <string name="ussd_code_summary">The app queries the USSD code %s to get the current balance</string>
     <string name="ussd_code_default" translatable="false"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,10 @@
     <string name="channel_name_balance_increased">Balance increased</string>
     <string name="channel_name_threshold_reached">Threshold reached</string>
     <string name="invalid_ussd_code">Invalid USSD code entered</string>
+    <string name="invalid_subscription">Invalid Subscription, check default</string>
     <string name="ussd_code">USSD code</string>
+    <string name="subscription_id">Subscription</string>
+    <string name="subscription_summary">Change default sim card</string>
     <string name="ussd_code_summary">The app queries the USSD code %s to get the current balance</string>
     <string name="ussd_code_default" translatable="false"/>
     <string name="general">General</string>

--- a/app/src/main/res/xml/pref_main.xml
+++ b/app/src/main/res/xml/pref_main.xml
@@ -10,7 +10,8 @@
             android:title="@string/ussd_code" />
         <ListPreference
             android:key="subscription_id"
-            android:title="@string/subscription_id" />
+            android:title="@string/subscription_id"
+            android:summary="@string/subscription_summary"/>
         <SwitchPreferenceCompat
             android:key="periodic_checks"
             android:defaultValue="false"

--- a/app/src/main/res/xml/pref_main.xml
+++ b/app/src/main/res/xml/pref_main.xml
@@ -11,7 +11,7 @@
         <ListPreference
             android:key="subscription_id"
             android:title="@string/subscription_id"
-            android:summary="@string/subscription_summary"/>
+            app:useSimpleSummaryProvider="true" />
         <SwitchPreferenceCompat
             android:key="periodic_checks"
             android:defaultValue="false"

--- a/app/src/main/res/xml/pref_main.xml
+++ b/app/src/main/res/xml/pref_main.xml
@@ -8,6 +8,9 @@
             android:key="ussd_code"
             android:defaultValue="@string/ussd_code_default"
             android:title="@string/ussd_code" />
+        <ListPreference
+            android:key="subscription_id"
+            android:title="@string/subscription_id" />
         <SwitchPreferenceCompat
             android:key="periodic_checks"
             android:defaultValue="false"


### PR DESCRIPTION
### Fixes #124 
Previouly on swipe behaviour, the app use to directly request USSD without having any user selection for a sim card.
In this PR, the user can see a dialog box from which a sim card can be chosen to proceed the request.
The sim card names shown to the user are directly coming from [SubscriptionInfo](https://developer.android.com/reference/android/telephony/SubscriptionInfo) object's [carrierName](https://developer.android.com/reference/android/telephony/SubscriptionInfo#getCarrierName()) method.

For convenience, if the device has only one sim card in it, then it does not show any list in a dialog, and the flow for the request is same as before.

![IMG_20221002_2339421](https://user-images.githubusercontent.com/51832211/193469486-dc8682a7-8485-442d-b35c-18c74dd7008f.jpg)
