### PR TITLE
Add USSD code for Telefonica Germany

### DIFF
--- a/app/src/main/res/values-mcc262-mnc003/strings.xml
+++ b/app/src/main/res/values-mcc262-mnc003/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Telefónica (Germany) -->
+    <string name="ussd_code_default" translatable="false">*100#</string>
+</resources>


### PR DESCRIPTION
Adds the USSD code for MCC 262, MNC 03.