### PR TITLE
speed up annotation processing: migrate Room `kapt`->`ksp`

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.20" />
+    <option name="version" value="1.9.22" />
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "com.android.application"
     id "kotlin-android"
-    id "kotlin-kapt"
+    id 'com.google.devtools.ksp'
     id "com.mikepenz.aboutlibraries.plugin"
 }
 
@@ -24,10 +24,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
-            }
+        ksp {
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 
@@ -77,7 +75,7 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:$workmanager_version"
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
     implementation "com.mikepenz:aboutlibraries:$about_libraries_version"
     implementation "androidx.core:core-splashscreen:1.0.1"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "com.android.application"
     id "kotlin-android"
-    id 'com.google.devtools.ksp'
+    id "com.google.devtools.ksp"
     id "com.mikepenz.aboutlibraries.plugin"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ buildscript {
     }
 }
 
+plugins {
+    // modern kotlin annotation support; replaces kapt: https://developer.android.com/build/migrate-to-ksp
+    id 'com.google.devtools.ksp' version '1.9.22-1.0.17' apply false
+}
+
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
hi @mueller-ma ,

Thanks for the great app, I've been using it happily on my phone these last years.

I'm playing with the code to see if I can (eventually, don't get your hopes up), do something about proper multi-sim, parallel tracker support.

In the meantime, just to get my feet wet, here is an unblock for the current dependabot build failures (#271).

While doing that, my IDE told me that "ksp" is faster than kapt for annotations, so I migrated that as well.

Hope this helps!