### PR TITLE
Settings: use `displayName` if `carrierName` is not set.

### DIFF
--- a/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
+++ b/app/src/main/java/com/github/muellerma/prepaidbalance/ui/PreferenceActivity.kt
@@ -154,7 +154,7 @@ class PreferenceActivity : AbstractBaseActivity() {
             val subscriptionManager = requireContext().getSystemService(SubscriptionManager::class.java)
             val (subscriptionIds, carrierNames) = subscriptionManager.activeSubscriptionInfoList.let { subscriptions ->
                 val subscriptionIds = subscriptions.map { "${it.subscriptionId}" }.toTypedArray()
-                val carrierNames = subscriptions.map { it.carrierName }.toTypedArray()
+                val carrierNames = subscriptions.map { it.carrierName.ifBlank { it.displayName } }.toTypedArray()
                 subscriptionIds to carrierNames
             }
 


### PR DESCRIPTION
I've scratched together enough free time to fix the issue I researched in #296 .
As usual, figuring out **what** the problem was took 10x the time as actually solving it :sweat_smile: 

As documented in #296, the UI-setting element will mis-detect an empty sim-card name string as "not set", even though the setting is active (underlying setting uses the slot-index, so all other machinery works).

I'm adding a fallback to `displayName` (user-settable) under those circumstances.
Showing what the user calls the sim-card is definitely better than nothing.

Open to discussion: should user-chosen `displayName` always be preferred over system-defined `carrierName`?   
The carriername is what is shown on the status-bar, so is what most people probably recognise the fastest.

closes #296 